### PR TITLE
fix importing on boards where time.monotonic_ns raises NotImplementedError

### DIFF
--- a/adafruit_ticks.py
+++ b/adafruit_ticks.py
@@ -74,7 +74,7 @@ except (ImportError, NameError):
             until a holiday."""
             return (_monotonic_ns() // 1_000_000) & _TICKS_MAX
 
-    except (ImportError, NameError):
+    except (ImportError, NameError, NotImplementedError):
         from time import monotonic as _monotonic
 
         def ticks_ms():


### PR DESCRIPTION
A QT Py M0 would error like so:
```
Auto-reload is on. Simply save files over USB to run them or enter REPL to disable.
code.py output:
Traceback (most recent call last):
  File "code.py", line 1, in <module>
  File "adafruit_ticks.py", line 58, in <module>
NotImplementedError: No long integer support
```
Catch this error and fall back to `time.monotonic` as intended.

Tested on a QT Py M0 with CircuitPython 7.0.0-alpha.4, which had not yet added `supervisor.ticks_ms`, and then with alpha.5 which does.