### PR TITLE
fix circup install command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ following command to install:
 
 .. code-block:: shell
 
-    circup install ticks
+    circup install adafruit_ticks
 
 Or the following command to update an existing version:
 


### PR DESCRIPTION
The circup install command in the readme was excluding the `adafruit_` prefix so that command was not able to complete successfully.

This change updates the command to:

```
circup install adafruit_ticks
```

I tested the updated command succesfully with a FunHouse on 7.0.0 alpha5 (though device an version shouldn't make a different I don't think).