### PR TITLE
raise an OverflowError like micropython for too big a value

### DIFF
--- a/adafruit_ticks.py
+++ b/adafruit_ticks.py
@@ -122,7 +122,7 @@ except (ImportError, NameError):
 
 def ticks_add(ticks: int, delta: int) -> int:
     "Add a delta to a base number of ticks, performing wraparound at 2**29ms."
-    if delta <= -_TICKS_PERIOD/2 or delta >= _TICKS_PERIOD/2:
+    if delta <= -_TICKS_PERIOD / 2 or delta >= _TICKS_PERIOD / 2:
         raise OverflowError("ticks interval overflow")
     return (ticks + delta) % _TICKS_PERIOD
 

--- a/adafruit_ticks.py
+++ b/adafruit_ticks.py
@@ -122,9 +122,9 @@ except (ImportError, NameError):
 
 def ticks_add(ticks: int, delta: int) -> int:
     "Add a delta to a base number of ticks, performing wraparound at 2**29ms."
-    if delta <= -_TICKS_PERIOD / 2 or delta >= _TICKS_PERIOD / 2:
-        raise OverflowError("ticks interval overflow")
-    return (ticks + delta) % _TICKS_PERIOD
+    if  -_TICKS_HALFPERIOD < delta < _TICKS_HALFPERIOD:
+        return (ticks + delta) % _TICKS_PERIOD
+     raise OverflowError("ticks interval overflow")
 
 
 def ticks_diff(ticks1: int, ticks2: int) -> int:

--- a/adafruit_ticks.py
+++ b/adafruit_ticks.py
@@ -124,7 +124,7 @@ def ticks_add(ticks: int, delta: int) -> int:
     "Add a delta to a base number of ticks, performing wraparound at 2**29ms."
     if  -_TICKS_HALFPERIOD < delta < _TICKS_HALFPERIOD:
         return (ticks + delta) % _TICKS_PERIOD
-     raise OverflowError("ticks interval overflow")
+    raise OverflowError("ticks interval overflow")
 
 
 def ticks_diff(ticks1: int, ticks2: int) -> int:

--- a/adafruit_ticks.py
+++ b/adafruit_ticks.py
@@ -122,7 +122,7 @@ except (ImportError, NameError):
 
 def ticks_add(ticks: int, delta: int) -> int:
     "Add a delta to a base number of ticks, performing wraparound at 2**29ms."
-    if  -_TICKS_HALFPERIOD < delta < _TICKS_HALFPERIOD:
+    if -_TICKS_HALFPERIOD < delta < _TICKS_HALFPERIOD:
         return (ticks + delta) % _TICKS_PERIOD
     raise OverflowError("ticks interval overflow")
 

--- a/adafruit_ticks.py
+++ b/adafruit_ticks.py
@@ -122,6 +122,8 @@ except (ImportError, NameError):
 
 def ticks_add(ticks: int, delta: int) -> int:
     "Add a delta to a base number of ticks, performing wraparound at 2**29ms."
+    if delta <= -_TICKS_PERIOD/2 or delta >= _TICKS_PERIOD/2:
+        raise OverflowError("ticks interval overflow")
     return (ticks + delta) % _TICKS_PERIOD
 
 


### PR DESCRIPTION
This allows the micropython test "ticks_add" to succeed when the adafruit_ticks implementation of ticks_add is used. (see https://github.com/adafruit/circuitpython/blob/main/extmod/modtime.c#L191)